### PR TITLE
Handle a no response from confirmation in the 3rd question

### DIFF
--- a/.ask/config
+++ b/.ask/config
@@ -6,13 +6,11 @@
       "merge": {},
       "resources": {
         "manifest": {
-          "eTag": "180cf6d9652a0189e7b89fa4c2271b4f"
+          "eTag": "21395eed0c6e030a0ea8aa4ee4c196f4"
         },
         "interactionModel": {
           "en-US": {
-
-            "eTag": "af9f036cbbd96d5864d84083f82bc5a1"
-
+            "eTag": "1572977f71c2b5413e581f3a01a69fbd"
           }
         },
         "lambda": [
@@ -25,8 +23,7 @@
             "codeUri": "lambda/custom",
             "functionName": "ask-custom-file-an-appeal-ASUCapstone",
             "handler": "index.handler",
-            "revisionId": "05ccfea8-532c-4b1f-baa2-d83dd7411423",
-
+            "revisionId": "df8c11fc-7e46-4dd0-9a59-4d284d77360d",
             "runtime": "nodejs8.10"
           }
         ]

--- a/lambda/custom/index.js
+++ b/lambda/custom/index.js
@@ -190,13 +190,17 @@ const YesIntentHandler = {
 
 
         // Question 3 Steps Taken
-        else if (prevIntent === 'ActionTaken'){
-            speechOutput = "Okay, what steps have you taken to prevent this from happening again?";
+        else if (prevIntent === 'ActionTaken'|| prevIntent === 'noStepsTaken'){
+            if (prevIntent === 'noStepsTaken') {	
+        		speechOutput = 'Ok, let\'s try this again. What steps have you taken to prevent this issue from happening again?';
+        	} else {
+        		speechOutput = "Okay! What steps have you taken to prevent this issue from happening again?";
+        	}
 
             sessionAttributes.previousIntent = 'GoToStepsTaken';
         }
 
-        //Question 4 Prevention
+        //Finish and save to dynamo
         else if (prevIntent === 'StepsTaken'){
             
             //Collect poaId number and user input for storage into DynamoDb table
@@ -271,10 +275,18 @@ const NoIntentHandler = {
 	        	speechOutput = "Ok, would you like to try and answer action taken again?";
 	        	reprompt = "I didn't quite get that. You could say, yes, or you could say, cancel.";
 	        	
-	        	sessionAttributes.previousIntent = 'noActionTaken';
-	        
-	        // US44_TSK46 Steven Foust
-	        } else if (prevIntent === 'noContinue'
+	        	sessionAttributes.previousIntent = 'noActionTaken';        
+            } 
+
+            else if(prevIntent === 'StepsTaken'){
+                
+                speechOutput = "Ok, would you like to try and answer steps taken again?";
+	        	reprompt = "I didn't quite get that. You could say, yes, or you could say, cancel.";
+	        	
+	        	sessionAttributes.previousIntent = 'noStepsTaken';
+            }
+            // US44_TSK46 Steven Foust
+            else if (prevIntent === 'noContinue'
 	        	|| prevIntent === 'noActionTaken'
                     || prevIntent === 'noStepsTaken'
                         || prevIntent === 'LaunchRequest') {


### PR DESCRIPTION
This commit implements code to handle when a user says no when confirming input
on the 3rd question in the POA process.  After a no reponse, the user is
prompted to say their response again.

*Issue #, if available:*

*Description of changes:*
Implements code to handle a no response from confirmation of the input for the 3rd question.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
