### PR TITLE
61 64 final confirm no single q

### DIFF
--- a/.ask/config
+++ b/.ask/config
@@ -23,7 +23,7 @@
             "codeUri": "lambda/custom",
             "functionName": "ask-custom-file-an-appeal-ASUCapstone",
             "handler": "index.handler",
-            "revisionId": "dc026871-eef3-4c9f-9d14-341b1a4d686e",
+            "revisionId": "15f6a7c7-d83a-4a4e-8f6a-5ef9c71b64d2",
             "runtime": "nodejs8.10"
           }
         ]

--- a/lambda/custom/index.js
+++ b/lambda/custom/index.js
@@ -19,6 +19,7 @@ const LaunchRequestHandler = {
         const attributesManager = handlerInput.attributesManager;
         const sessionAttributes = attributesManager.getSessionAttributes();
         sessionAttributes.previousIntent = 'LaunchRequest';
+        sessionAttributes.singleAnswerEntry = 'false';
 
 
         const speakOutput = 'Welcome to the appeal process. Would you like to begin with the first question?';
@@ -62,7 +63,7 @@ const RootCauseHandler = {
         sessionAttributes.qst1 = handlerInput.requestEnvelope.request.intent.slots.Query.value;
 
         const speechOutput = "You have entered that the root cause of the issue was " + sessionAttributes.qst1 +
-            ". Is this the response that you would like to submit?";
+            ". Is this correct?";
 
 
         return handlerInput.responseBuilder
@@ -78,7 +79,7 @@ const ActionTakenHandler = {
 
         return Alexa.getRequestType(handlerInput.requestEnvelope) === 'IntentRequest'
             && Alexa.getIntentName(handlerInput.requestEnvelope) === 'ActionTaken'
-            && (sessionAttributes.previousIntent === 'GoToActionTaken'||sessionAttributes.previousIntent === 'AMAZON.HelpIntent');
+            && (sessionAttributes.previousIntent === 'GoToActionTaken'||sessionAttributes.previousIntent === 'startOver'||sessionAttributes.previousIntent === 'AMAZON.HelpIntent');
     },
     handle(handlerInput){
         const sessionAttributes = handlerInput.attributesManager.getSessionAttributes();
@@ -102,7 +103,7 @@ const StepsTakenHandler = {
 
         return Alexa.getRequestType(handlerInput.requestEnvelope) === 'IntentRequest'
         && Alexa.getIntentName(handlerInput.requestEnvelope) === 'StepsTaken'
-        && (sessionAttributes.previousIntent === 'GoToStepsTaken'||sessionAttributes.previousIntent === 'AMAZON.HelpIntent');
+        && (sessionAttributes.previousIntent === 'GoToStepsTaken'||sessionAttributes.previousIntent === 'startOver'||sessionAttributes.previousIntent === 'AMAZON.HelpIntent');
     },
     handle(handlerInput){
         const sessionAttributes = handlerInput.attributesManager.getSessionAttributes();
@@ -140,82 +141,13 @@ const YesIntentHandler = {
         var reprompt = "";
 
 
-      const attributesManager = handlerInput.attributesManager;        
+        const attributesManager = handlerInput.attributesManager;        
         const persistentAttributes = await attributesManager.getPersistentAttributes() || {};
         const sessionAttributes = handlerInput.attributesManager.getSessionAttributes();
         var prevIntent = sessionAttributes.previousIntent;
 
-        
-        // Question 1
-        if (prevIntent === 'LaunchRequest' || prevIntent === 'AMAZON.HelpIntent'|| prevIntent === 'noContinue'||prevIntent === 'startOver') {
-               
-          reprompt = "I'm sorry, I didn't get that. What is the root cause of the issue?";         
-            
-          if(Object.keys(persistentAttributes).length ===0){
-                sessionAttributes.poaId = 1;
-                persistentAttributes.poaId = 2;
-                attributesManager.setPersistentAttributes(persistentAttributes);
-                await attributesManager.savePersistentAttributes();
-            }else{
-                sessionAttributes.poaId = persistentAttributes.poaId;
-                persistentAttributes.poaId += 1;
-                attributesManager.setPersistentAttributes(persistentAttributes);
-                await attributesManager.savePersistentAttributes();
-            }
-            
-            // US44_TSK45 Steven Foust
-            if(prevIntent === 'noContinue'||prevIntent === 'startOver') {                
-                speechOutput = 'Ok, let\'s try this again. What is the root cause of the issue?';
-                sessionAttributes.singleAnswerEntry = 'false';
-            } else {                
-            	speechOutput = "Great, let's get started. What is the root cause of the issue?";            	
-            }
-            sessionAttributes.previousIntent = 'Continue';
-
-        }
-
-
-        // Question 2 Action Taken
-        else if (prevIntent === 'RootCause'
-        	|| prevIntent === 'noActionTaken') {
-        	
-        	// US44_TSK46 Steven Foust
-        	if (prevIntent === 'noActionTaken') {	
-        		speechOutput = 'Ok, let\'s try this again. What actions have you taken to resolve the issue?';
-        	} else {
-        		speechOutput = "Okay! What actions have you taken to resolve the issue?";
-        	}
-            
-            sessionAttributes.previousIntent = 'GoToActionTaken';
-        }
-
-
-        // Question 3 Steps Taken
-        else if (prevIntent === 'ActionTaken'|| prevIntent === 'noStepsTaken'){
-            if (prevIntent === 'noStepsTaken') {	
-        		speechOutput = 'Ok, let\'s try this again. What steps have you taken to prevent this issue from happening again?';
-        	} else {
-        		speechOutput = "Okay! What steps have you taken to prevent this issue from happening again?";
-        	}
-
-            sessionAttributes.previousIntent = 'GoToStepsTaken';
-        }
-
-        //Confirm complete user entry before submission
-        else if(prevIntent === 'StepsTaken'){
-            let d1 = sessionAttributes.qst1;
-            let d2 = sessionAttributes.qst2;
-            let d3 = sessionAttributes.qst3;
-
-            speechOutput = `Here is your completed plan of action. \ 
-                You said the root cause of your issue was ${d1}, you fixed this issue by ${d2}, and this won't happen again because you will ${d3}. \
-                  Does that sound right?`;
-
-                sessionAttributes.previousIntent = 'finish';
-        }
-        
         //Finish and save to dynamo
-        else if (prevIntent === 'finish'){
+        if (prevIntent === 'finish'){
             
             //Collect poaId number and user input for storage into DynamoDb table
             let id = `${sessionAttributes.poaId}`;
@@ -251,6 +183,70 @@ const YesIntentHandler = {
                 .speak(speechOutput)
                 .getResponse();
             
+        }
+        
+        // Question 1
+        else if ((prevIntent === 'LaunchRequest' || prevIntent === 'AMAZON.HelpIntent'|| prevIntent === 'noContinue'||prevIntent === 'startOver') && sessionAttributes.singleAnswerEntry === 'false') {
+               
+          reprompt = "I'm sorry, I didn't get that. What is the root cause of the issue?";         
+            
+          if(Object.keys(persistentAttributes).length ===0){
+                sessionAttributes.poaId = 1;
+                persistentAttributes.poaId = 2;
+                attributesManager.setPersistentAttributes(persistentAttributes);
+                await attributesManager.savePersistentAttributes();
+            }else{
+                sessionAttributes.poaId = persistentAttributes.poaId;
+                persistentAttributes.poaId += 1;
+                attributesManager.setPersistentAttributes(persistentAttributes);
+                await attributesManager.savePersistentAttributes();
+            }
+            
+            // US44_TSK45 Steven Foust
+            if(prevIntent === 'noContinue'||prevIntent === 'startOver') {                
+                speechOutput = 'Ok, let\'s try this again. What is the root cause of the issue?';
+            } else {                
+            	speechOutput = "Great, let's get started. What is the root cause of the issue?";            	
+            }
+            sessionAttributes.previousIntent = 'Continue';
+
+        }
+
+        // Question 2 Action Taken
+        else if ((prevIntent === 'RootCause'|| prevIntent === 'noActionTaken') && sessionAttributes.singleAnswerEntry === 'false') {
+        	
+        	// US44_TSK46 Steven Foust
+        	if (prevIntent === 'noActionTaken') {	
+        		speechOutput = 'Ok, let\'s try this again. What actions have you taken to resolve the issue?';
+        	} else {
+        		speechOutput = "Okay! What actions have you taken to resolve the issue?";
+        	}
+            
+            sessionAttributes.previousIntent = 'GoToActionTaken';
+        }
+
+        // Question 3 Steps Taken
+        else if ((prevIntent === 'ActionTaken'|| prevIntent === 'noStepsTaken') && sessionAttributes.singleAnswerEntry === 'false'){
+            if (prevIntent === 'noStepsTaken') {	
+        		speechOutput = 'Ok, let\'s try this again. What steps have you taken to prevent this issue from happening again?';
+        	} else {
+        		speechOutput = "Okay! What steps have you taken to prevent this issue from happening again?";
+        	}
+
+            sessionAttributes.previousIntent = 'GoToStepsTaken';
+        }
+
+        //Confirm complete user entry before submission
+        else if(prevIntent === 'StepsTaken'||sessionAttributes.singleAnswerEntry === 'true'){
+            let d1 = sessionAttributes.qst1;
+            let d2 = sessionAttributes.qst2;
+            let d3 = sessionAttributes.qst3;
+
+            speechOutput = `Here is your completed plan of action. \ 
+                You said the root cause of your issue was ${d1}, you fixed this issue by ${d2}, and this won't happen again because you will ${d3}. \
+                  Does that sound right?`;
+
+                sessionAttributes.previousIntent = 'finish';
         }
 
         //Speak output and await reprompt
@@ -302,11 +298,22 @@ const NoIntentHandler = {
 
             else if(prevIntent === 'finish'){
                 
-                speechOutput = "Ok, would you like to start again from the beginning?  You can say yes to start over,\
+                speechOutput = "If you need to change more than one answer, I would recommend starting over from the beginning.\
+                    Would you like to start again from the beginning?  You can say yes to start over,\
                     say no to change just a single answer, or say cancel to quit and finish your plan of action at a later date.";
 	        	reprompt = "I didn't quite get that. You could say, yes, or you could say, cancel.";
 	        	
                 sessionAttributes.previousIntent = 'startOver';
+                sessionAttributes.singleAnswerEntry = 'false'
+            }
+
+            else if(prevIntent === 'startOver'){
+                
+                speechOutput = "Ok, you can say, the root cause was, to explain the root cause of the issue.\
+                    Or you can say, i fixed this by, to explain how you resolved the issue.\
+                        Or you can say, i plan to, to explain how you will prevent this issue from hapenning again.";
+	        	reprompt = "I didn't quite get that. You could say, yes, or you could say, cancel.";
+	        	
                 sessionAttributes.singleAnswerEntry = 'true';
             }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This enables the user to say no at the final confirmation of the complete plan of action and only change a single user input.  After changing a single user input, the skill goes back to confirming the completed plan of action.  This can be repeated for all questions, but since that is not efficient for the user the prompt encourages the user to just start over if they have to change more than one entry.

Recommend merging this after task 63.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
