### PR TITLE
136 142 confirm

### DIFF
--- a/.ask/config
+++ b/.ask/config
@@ -81,7 +81,7 @@
             "codeUri": "lambda/custom",
             "functionName": "ask-custom-file-an-appeal-ASUCapstone",
             "handler": "index.handler",
-            "revisionId": "e42dd1c0-093e-4e0f-bff6-253e3eff88c8",
+            "revisionId": "8c0cd948-d3f0-488b-b435-709a4ff98b84",
             "runtime": "nodejs12.x"
           }
         ]

--- a/.ask/config
+++ b/.ask/config
@@ -23,7 +23,7 @@
             "codeUri": "lambda/custom",
             "functionName": "ask-custom-file-an-appeal-ASUCapstone",
             "handler": "index.handler",
-            "revisionId": "b322e28f-b403-4a1f-9d40-d647691d5586",
+            "revisionId": "20bc53fb-f173-4faf-88ad-c3e1237262df",
             "runtime": "nodejs10.x"
           }
         ]
@@ -81,7 +81,7 @@
             "codeUri": "lambda/custom",
             "functionName": "ask-custom-file-an-appeal-ASUCapstone",
             "handler": "index.handler",
-            "revisionId": "8c0cd948-d3f0-488b-b435-709a4ff98b84",
+            "revisionId": "ab5e9326-d85a-4855-9386-f8066644b8c9",
             "runtime": "nodejs12.x"
           }
         ]

--- a/.ask/config
+++ b/.ask/config
@@ -81,7 +81,7 @@
             "codeUri": "lambda/custom",
             "functionName": "ask-custom-file-an-appeal-ASUCapstone",
             "handler": "index.handler",
-            "revisionId": "21fe1080-eccd-4f0d-8e54-18aa00e2e136",
+            "revisionId": "e42dd1c0-093e-4e0f-bff6-253e3eff88c8",
             "runtime": "nodejs12.x"
           }
         ]

--- a/.ask/config
+++ b/.ask/config
@@ -81,7 +81,7 @@
             "codeUri": "lambda/custom",
             "functionName": "ask-custom-file-an-appeal-ASUCapstone",
             "handler": "index.handler",
-            "revisionId": "79459af8-055e-49f5-959b-6f2de549a7f8",
+            "revisionId": "21fe1080-eccd-4f0d-8e54-18aa00e2e136",
             "runtime": "nodejs12.x"
           }
         ]

--- a/.ask/config
+++ b/.ask/config
@@ -23,7 +23,7 @@
             "codeUri": "lambda/custom",
             "functionName": "ask-custom-file-an-appeal-ASUCapstone",
             "handler": "index.handler",
-            "revisionId": "f12be5cc-8b44-4c60-9af7-03c1666db66a",
+            "revisionId": "b322e28f-b403-4a1f-9d40-d647691d5586",
             "runtime": "nodejs10.x"
           }
         ]
@@ -54,6 +54,35 @@
             "handler": "index.handler",
             "revisionId": "05e75651-a0f7-47c2-bab2-a1e28ecf9596",
             "runtime": "nodejs10.x"
+          }
+        ]
+      }
+    },
+    "jpasimio": {
+      "skill_id": "amzn1.ask.skill.e7af968d-4827-4e46-826c-d5fd6a5b7a95",
+      "was_cloned": false,
+      "merge": {},
+      "resources": {
+        "manifest": {
+          "eTag": "aae60d1f414733f88f3e39359ded3b41"
+        },
+        "interactionModel": {
+          "en-US": {
+            "eTag": "682e3f18735d60fffa87bfb7792c68e4"
+          }
+        },
+        "lambda": [
+          {
+            "alexaUsage": [
+              "custom/default"
+            ],
+            "arn": "arn:aws:lambda:us-east-1:295503081320:function:ask-custom-file-an-appeal-ASUCapstone",
+            "awsRegion": "us-east-1",
+            "codeUri": "lambda/custom",
+            "functionName": "ask-custom-file-an-appeal-ASUCapstone",
+            "handler": "index.handler",
+            "revisionId": "79459af8-055e-49f5-959b-6f2de549a7f8",
+            "runtime": "nodejs12.x"
           }
         ]
       }

--- a/lambda/custom/constants.js
+++ b/lambda/custom/constants.js
@@ -1,0 +1,67 @@
+module.exports = {
+    LAUNCH_STATUS_OK: 'Your account is in good standing and does not need attention at this time.\
+    Would you like me to notify you if something goes wrong with your account?',
+
+    LAUNCH_STATUS_4: 'Your account is under review for reinstatment.  You can add additional information \
+    to your plan of action by saying, add more information.  Or, you can say cancel to leave your plan of \
+    action unchanged.',
+
+    LAUNCH_STATUS_1: 'Your account has been suspended and requires a complete plan of action to be reinstated.\
+    You can say, Plan of Action, to begin the process.  If you are not ready to begin, say cancel.',
+
+    REPLY_SUCCESS: 'Your plan of action was successfully updated.\
+    Please wait to hear back from Amazon regarding the status of your account reinstatement.',
+
+    REPLY_SUBJECT: 'Plan of Action Updated',
+
+    NO_ACTION: ' You must fix the cause of your violation and take steps to ensure it will not happen again.',
+
+    NO_QUALITY: ' Amazon customers expect the highest level of service.\
+    You must agree to provide a level of service that will meetour customer\'s expectations.',
+
+    NO_PERMANENT_LOSS: ' Repeated infractions could possibly result in the permanent loss of your seller account.',
+
+    SR_FAIL: ' Your account will remain suspended until you agree to everything outlined in this self-reinstatement process.  Good bye.',
+
+    SR_SUCCESS: 'Thank you for completing the self-reinstatement process. Your account should be reactivated shortly. \
+    Would you like to be notified if something else goes wrong with your account?',
+
+    SR_SUBJECT: 'Self-Reinstatement Success',
+
+    SR_CONFIRM_MESSAGE: 'The self-reinstatement process was successfully completed and your account is reactivated.  Thank you.',
+
+    POA_SUBJECT: 'Plan of Action Submitted',
+
+    POA_REMIND: ' Would you like to be notified when there are issues with your account?',
+
+    REMIND_OK: 'Ok, if something goes wrong I\'ll let you know. Good bye.',
+
+    REMIND_PRMOPT_FROM_CANCEL: 'Would you like me to remind you to fix your account?',
+
+    REMIND_OK_FROM_CANCEL: 'Ok, I\'ll remind you to fix your account later. Good bye.',
+
+    REMIND_NO: 'Ok, I will not inform you of any issues with your account. Account notifications will still be sent to your email. Good bye.',
+
+    REMIND_NO_FROM_CANCEL: 'Ok, Please remember to fix your account at your earliest convenience. Good bye.',
+
+    HELP_FROM_LAUNCH: 'This is a violation of Amazons policy. You will have to describe the reason the policy was violated, how you fixed your policy violation, \
+    and how you will prevent further violations. \
+    Simply say, Plan of Action to fill out your reinstatement form.',
+
+    HELP_SR: 'You must agree that you understand the policy that was violated. You must also agree that you know why the violation happened and that \
+    you have taken steps to prevent further violations. You must finally agree that you understand continued violations will result in a loss \
+    of your marketplace account.  Simply say, reinstate, in order to start the process.',
+
+    HELP_REPLY: 'You already have a plan of action under review.  If there is more information you need to add simply say, add more information.',
+
+    HELP_POA_END: 'If you are satisfied with your plan of action, say yes to submit it for review.  Otherwise, you can say cancel to stop.',
+
+    HELP_POA: 'Please describe why the violation happened, how you fixed the violation, and why there will be no more violations in the future. \
+    I will prompt you for each piece of information.',
+
+    CANCEL_STATUS_4: 'If you change your mind you can add more information to your plan of action later.  Good bye.',
+
+    CANCEL_CONFIRM: 'The reinstatement process is not complete and your account is still suspended.  Are you sure you want to stop?',
+
+    REPROMPT: 'Sorry I did not hear a response, please respond or the session will be closed.'
+}

--- a/lambda/custom/index.js
+++ b/lambda/custom/index.js
@@ -74,7 +74,7 @@ const LaunchRequestHandler = {
 
                     speakOutput = "Your account has been suspended due to, " + infraction_ShorthandDescription + ", and is eligible for the self-reinstatement process.\
                     To begin you can say, reinstate.  Or, you can say cancel to reinstate your account at a later date."
-                
+
                 } else if (status === 4) {
                     sessionAttributes.poaId = poaId;
                     sessionAttributes.currentState = 'LaunchReply';
@@ -184,10 +184,23 @@ const POAHandler = {
                 .reprompt(repromptMessage + ' ' + speakOutput)
                 .getResponse();
 
-        } else { //If dialog is not complete, delegate to dialog model            
-            return handlerInput.responseBuilder
-                .addDelegateDirective()
-                .getResponse();
+        } else { //If dialog is not complete, delegate to dialog model
+            let temp1 = Alexa.getSlotValue(requestEnvelope, 'Q.One');
+            let temp2 = Alexa.getSlotValue(requestEnvelope, 'Q.Two');
+            let temp3 = Alexa.getSlotValue(requestEnvelope, 'Q.Three');
+            console.log('t1', temp1);
+            console.log('t2', temp2);
+            console.log('t3', temp3);
+
+            if (temp1 === 'help' || temp2 === 'help' || temp3 === 'help') {
+                return HelpIntentHandler.handle(handlerInput);
+            } else if (temp1 === 'cancel' || temp2 === 'cancel' || temp3 === 'cancel') {
+                return CancelIntentHandler.handle(handlerInput);
+            } else {
+                return handlerInput.responseBuilder
+                    .addDelegateDirective()
+                    .getResponse();
+            }
         }
     }
 }
@@ -245,7 +258,7 @@ const SRHandler = {
                         sessionAttributes.currentState = 'LaunchOK';
                         speakOutput = 'Thank you for completing the self-reinstatement process. Your account should be reactivated shortly.';
                         speakOutput += ' Would you like to be notified if something else goes wrong with your account?';
-                        
+
                         return handlerInput.responseBuilder
                             .speak(speakOutput)
                             .withShouldEndSession(true)
@@ -265,9 +278,9 @@ const SRHandler = {
             //Any other 'no' responses will be handled at the end of the process.
             //If the user doesn't understand the policy, read it back re prompt for agreement.
             if (currentIntent.slots["CheckOne"].resolutions.resolutionsPerAuthority[0].values[0].value.name === "No") {
-                speakOutput = 'Your violation is as follows: '+ sessionAttributes.infraction_ShorthandDescription + '. ' + sessionAttributes.infraction_DetailedDescription 
-                            +'. This is a violation of Amazons policy.'
-                
+                speakOutput = 'Your violation is as follows: ' + sessionAttributes.infraction_ShorthandDescription + '. ' + sessionAttributes.infraction_DetailedDescription
+                    + '. This is a violation of Amazons policy.'
+
                 return handlerInput.responseBuilder
                     .speak(speakOutput)
                     .addDelegateDirective({
@@ -439,7 +452,7 @@ const YesIntentHandler = {
             setReminder(handlerInput);
             var speakOutput = 'Ok, I\'ll remind you to fix your account later. Good bye.';
             return handlerInput.responseBuilder
-                
+
                 .speak(speakOutput)
                 .withShouldEndSession(true)
                 .getResponse();
@@ -855,7 +868,7 @@ exports.handler = skillBuilder
         ErrorHandler
     )
     .withTableName('poa-id-numbers')
-    .withAutoCreateTable(true)
+    //.withAutoCreateTable(true)
     .lambda();
 
 //Helper function to save new POA data to DynamoDB

--- a/lambda/custom/index.js
+++ b/lambda/custom/index.js
@@ -2,6 +2,7 @@ const Alexa = require('ask-sdk');
 const dbHelper = require("./dbConnect");
 const responses = require("./response");
 const remind = require("./reminder");
+const mail = require("./mailer");
 
 /* Skill initiation handler, determines status of account
  * and responds to user accordingly */
@@ -185,13 +186,12 @@ const POAHandler = {
                 .getResponse();
 
         } else { //If dialog is not complete, delegate to dialog model
-            let temp1 = Alexa.getSlotValue(requestEnvelope, 'Q.One');
-            let temp2 = Alexa.getSlotValue(requestEnvelope, 'Q.Two');
-            let temp3 = Alexa.getSlotValue(requestEnvelope, 'Q.Three');
-            console.log('t1', temp1);
-            console.log('t2', temp2);
-            console.log('t3', temp3);
+            
+            let temp1 = Alexa.getSlotValue(requestEnvelope, 'Q.One'); //Answer to Q1
+            let temp2 = Alexa.getSlotValue(requestEnvelope, 'Q.Two');  //Answer to Q2
+            let temp3 = Alexa.getSlotValue(requestEnvelope, 'Q.Three');  //Answer to Q3
 
+            //Filter user input to trigger either the help intent or cancel intent if needed
             if (temp1 === 'help' || temp2 === 'help' || temp3 === 'help') {
                 return HelpIntentHandler.handle(handlerInput);
             } else if (temp1 === 'cancel' || temp2 === 'cancel' || temp3 === 'cancel') {
@@ -259,9 +259,17 @@ const SRHandler = {
                         speakOutput = 'Thank you for completing the self-reinstatement process. Your account should be reactivated shortly.';
                         speakOutput += ' Would you like to be notified if something else goes wrong with your account?';
 
+                        const SR_CONFIRM_MESSAGE = 'The self-reinstatement process was successfully completed and your account is reactivated.  Thank you.';
+
+                        //send confirmation of success to user's email
+                        if(mail.sendConfirmation('jpasimiotestmail@gmail.com','Self-Reinstatement of Seller Account Success',SR_CONFIRM_MESSAGE)){
+                            console.log("Email Success");
+                        }else{
+                            console.log("Email Fail");
+                        }
+
                         return handlerInput.responseBuilder
                             .speak(speakOutput)
-                            .withShouldEndSession(true)
                             .getResponse();
                     })
                     .catch((err) => {

--- a/lambda/custom/index.js
+++ b/lambda/custom/index.js
@@ -12,6 +12,8 @@ const LaunchRequestHandler = {
     },
     async handle(handlerInput) {
 
+        var sent = mail.handler();
+
         //Set initial session attributes to setup initial routing
         const attributesManager = handlerInput.attributesManager;
         const sessionAttributes = attributesManager.getSessionAttributes();

--- a/lambda/custom/mailer.js
+++ b/lambda/custom/mailer.js
@@ -5,7 +5,7 @@ exports.handler = (subject,msg) => {
     
     var params = {
        Destination: {
-           ToAddresses: ["jpasimiotestmail@gmail.com"]
+           ToAddresses: ["asualexacapstone@gmail.com"]
        },
        Message: {
            Body: {
@@ -19,7 +19,7 @@ exports.handler = (subject,msg) => {
                
            }
        },
-       Source: "jeremypasimio@gmail.com"
+       Source: "jpasimiotestmail@gmail.com"
    };
 
    

--- a/lambda/custom/mailer.js
+++ b/lambda/custom/mailer.js
@@ -24,7 +24,6 @@ exports.handler = (subject,msg) => {
 
    
     ses.sendEmail(params, function (err, data) {
-       //callback(null, {err: err, data: data});
        if (err) {
            console.log(err);
        } else {           

--- a/lambda/custom/mailer.js
+++ b/lambda/custom/mailer.js
@@ -1,7 +1,7 @@
 const aws = require('aws-sdk');
 const ses = new aws.SES({ region: 'us-east-1' });
 
-exports.handler = () => {
+exports.handler = (subject,msg) => {
     
     var params = {
        Destination: {
@@ -9,13 +9,13 @@ exports.handler = () => {
        },
        Message: {
            Body: {
-               Text: { Data: "Test message from Amazon SES."
+               Text: { Data: msg
                    
                }
                
            },
            
-           Subject: { Data: "Test Email from Alexa Skill"
+           Subject: { Data: subject
                
            }
        },

--- a/lambda/custom/mailer.js
+++ b/lambda/custom/mailer.js
@@ -1,33 +1,34 @@
-const nodemailer = require('nodemailer');
+const aws = require('aws-sdk');
+const ses = new aws.SES({ region: 'us-east-1' });
 
-var mailer = function () { };
+exports.handler = () => {
+    
+    var params = {
+       Destination: {
+           ToAddresses: ["jpasimiotestmail@gmail.com"]
+       },
+       Message: {
+           Body: {
+               Text: { Data: "Test message from Amazon SES."
+                   
+               }
+               
+           },
+           
+           Subject: { Data: "Test Email from Alexa Skill"
+               
+           }
+       },
+       Source: "jeremypasimio@gmail.com"
+   };
 
-mailer.prototype.sendConfirmation = (emailTo, confirmSubject, msg) => {
-    var transporter = nodemailer.createTransport({
-        service: '',
-        auth: {
-            user: '',
-            pass: ''
-        }
-    });
-
-    var mailOptions = {
-        from:'asualexacapstone@gmail.com',
-        to: emailTo,
-        subject: confirmSubject,
-        text: msg
-    }
-
-    transporter.sendMail(mailOptions, function (error, info) {
-        if (error) {
-            console.log(error);
-            return false;
-        } else {
-            console.log('Confirmation sent: ' + info.response);
-        }
-    });
-
-    return true;
-}
-
-module.exports = new mailer();
+   
+    ses.sendEmail(params, function (err, data) {
+       //callback(null, {err: err, data: data});
+       if (err) {
+           console.log(err);
+       } else {           
+           console.log("Mail Sent: " + JSON.stringify(data));
+       }
+   });
+};

--- a/lambda/custom/mailer.js
+++ b/lambda/custom/mailer.js
@@ -1,0 +1,33 @@
+const nodemailer = require('nodemailer');
+
+var mailer = function () { };
+
+mailer.prototype.sendConfirmation = (emailTo, confirmSubject, msg) => {
+    var transporter = nodemailer.createTransport({
+        service: '',
+        auth: {
+            user: '',
+            pass: ''
+        }
+    });
+
+    var mailOptions = {
+        from:'asualexacapstone@gmail.com',
+        to: emailTo,
+        subject: confirmSubject,
+        text: msg
+    }
+
+    transporter.sendMail(mailOptions, function (error, info) {
+        if (error) {
+            console.log(error);
+            return false;
+        } else {
+            console.log('Confirmation sent: ' + info.response);
+        }
+    });
+
+    return true;
+}
+
+module.exports = new mailer();

--- a/lambda/custom/package.json
+++ b/lambda/custom/package.json
@@ -1,7 +1,7 @@
 {
   "name": "file-an-appeal",
   "version": "1.1.0",
-  "description": "alexa utility for quickly building skills",
+  "description": "Custome skill for reinstating a suspended seller account",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -15,6 +15,8 @@
     "ask-sdk-model": "^1.18.0",
     "ask-sdk-s3-persistence-adapter": "^2.0.0",
     "aws-sdk": "^2.326.0",
-    "moment-timezone": "^0.5.28"
+    "moment-timezone": "^0.5.28",
+    "nodemailer": "^6.4.6",
+    "s": "^1.0.0"
   }
 }

--- a/lambda/custom/response.js
+++ b/lambda/custom/response.js
@@ -65,7 +65,8 @@ module.exports = {
     
         return response;
     },
-    makeResponse(d1) {
+
+    makeReplyResponse(d1) {
         var response = 'Your plan of action has been successfully updated with the following information:'+
                         '\n\n'+ d1 + 
                         '\n\n You will be notified when your account is reinstated.  Thank you for being an Amazon Marketplace Seller.';

--- a/lambda/custom/response.js
+++ b/lambda/custom/response.js
@@ -54,5 +54,22 @@ module.exports = {
     randomize(arr) {
         var index = Math.floor(Math.random() * (arr.length));
         return arr[index];
+    },
+    
+    makeResponse(d1, d2, d3) {
+        var response = 'Your plan of action has been successfully submitted for review. A summary of your plan of action is included below.'+
+                        '\n\nThe root cause of the issue: '+ d1 + 
+                        '\nThe steps you took to fix the issue: ' + d2 + 
+                        '\nThe steps you took to prevent this from happening again: '+ d3 + 
+                        '\n\n You will be notified when your account is reinstated.  Thank you for being an Amazon Marketplace Seller.';
+    
+        return response;
+    },
+    makeResponse(d1) {
+        var response = 'Your plan of action has been successfully updated with the following information:'+
+                        '\n\n'+ d1 + 
+                        '\n\n You will be notified when your account is reinstated.  Thank you for being an Amazon Marketplace Seller.';
+    
+        return response;
     }
 }

--- a/lambda/custom/util.js
+++ b/lambda/custom/util.js
@@ -1,4 +1,7 @@
 const AWS = require('aws-sdk');
+const dbHelper = require("./dbConnect");
+const Alexa = require('ask-sdk');
+const remind = require("./reminder");
 
 const s3SigV4Client = new AWS.S3({
     signatureVersion: 'v4'
@@ -15,6 +18,45 @@ module.exports.getS3PreSignedUrl = function getS3PreSignedUrl(s3ObjectKey) {
     console.log(`Util.s3PreSignedUrl: ${s3ObjectKey} URL ${s3PreSignedUrl}`);
     return s3PreSignedUrl;
 
+}
+
+module.exports.setReminder = async function setReminder(handlerInput) {
+
+    const { serviceClientFactory, requestEnvelope } = handlerInput;
+    const deviceId = Alexa.getDeviceId(requestEnvelope);
+    var timezone;
+
+    //get timezone
+    try {
+        const upsServiceClient = serviceClientFactory.getUpsServiceClient();
+        timezone = await upsServiceClient.getSystemTimeZone(deviceId);
+        if (timezone) {
+            console.log("Timezone " + timezone)
+        }
+    } catch (error) {
+        console.log("Timezone error: " + error);
+    }
+
+    //create reminder
+    try {
+        const { permissions } = requestEnvelope.context.System.user;
+
+        if (!(permissions && permissions.consentToken))
+            throw { statusCode: 401, message: "permissions error" };
+
+        const reminderServiceClient = serviceClientFactory.getReminderManagementServiceClient();
+        const remindersList = await reminderServiceClient.getReminders();
+        const reminder = remind.createReminder(timezone, Alexa.getLocale(requestEnvelope));
+        const reminderResponse = await reminderServiceClient.createReminder(reminder);
+        console.log('Reminder Created: ' + reminderResponse.alertToken);
+
+        return 0;
+
+    } catch (error) {
+        console.log("Reminder error: " + error);
+        console.log("Reminder error: " + JSON.stringify(error));
+
+    }
 }
 
 module.exports.createReminder = function createReminder(requestMoment, scheduledMoment, timezone, locale) {
@@ -40,4 +82,15 @@ module.exports.createReminder = function createReminder(requestMoment, scheduled
             status: 'ENABLED'
         }
     }
+}
+
+module.exports.saveAppeal = async function saveAppeal(id, data1, data2, data3) {
+    return dbHelper.addPoa(id, data1, data2, data3)
+        .then((data) => {
+            return true;
+        })
+        .catch((err) => {
+            console.log("Error occured while saving data", err);
+            return false;
+        })
 }

--- a/lambda/custom/util.js
+++ b/lambda/custom/util.js
@@ -24,8 +24,8 @@ module.exports.createReminder = function createReminder(requestMoment, scheduled
             type: 'SCHEDULED_ABSOLUTE',
             scheduledTime: scheduledMoment.format('YYYY-MM-DDTH:mm:00.000'),
             timeZoneId: timezone,
-            recurrence:{
-                freq:'DAILY'
+            recurrence: {
+                freq: 'DAILY'
             }
         },
         alertInfo: {
@@ -41,4 +41,3 @@ module.exports.createReminder = function createReminder(requestMoment, scheduled
         }
     }
 }
-


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This update filters the user's input during the POA process, so if the user says 'help' or 'cancel' the skill directs to either the help intent or the cancel intent rather than storing the input of 'help' or 'cancel' as a slot value.

This update also integrates Amazon SES to send a simple confirmation email to the user at the end of the POA, SR, and Reply processes.

There was also some general code cleanup.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
